### PR TITLE
Add support for ctrl and shift in keyboard.luad

### DIFF
--- a/lua/keyboard.lua
+++ b/lua/keyboard.lua
@@ -88,6 +88,22 @@ keyboard.F9 = 184
 --keyboard.F10 = nil -- F10 doesn't seem to exist
 keyboard.F11 = 186
 keyboard.F12 = 187
+keyboard.shift = {}
+keyboard.shift.ctrl = {}
+keyboard.ctrl = {}
+keyboard.ctrl.shift = {}
 
+local shift_offset = 256
+local ctrl_offset = 512
+
+for i,v in pairs(keyboard) do
+	if i ~= "ctrl" and i ~= "shift" 
+	then
+		keyboard.shift[i] = shift_offset + v
+		keyboard.ctrl[i] = ctrl_offset + v
+		keyboard.shift.ctrl[i] = shift_offset + ctrl_offset + v
+		keyboard.ctrl.shift[i] = shift_offset + ctrl_offset + v
+	end
+end
 
 return keyboard


### PR DESCRIPTION
Since we have discovered that key+ctrl is key + 512 and key + shift
is key + 256, we can create an embedded table for each key + ctrl or
shift or both. So with this commit

      keyboard.ctrl.a
      keyboard.ctrl.shift.a
      keyboard.shift.a
      keyboard.shift.ctrl.a

become available. Yes, keyboard.ctrl.shift.a and keyboard.shift.ctrl.a
are duplicated but it's not costly to duplicate them and makes easier
for whoever is writing (does not need to remember which one is the right
one)

Change-Id: I45367c9b1e9f803d7e62fdfcd25b84426943a836